### PR TITLE
Address usability issues on mobile

### DIFF
--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -105,11 +105,17 @@
     color: #64b6f7;
 }
 
+#pds-app-bar-info {
+    margin-right: 14px;
+}
+#pds-app-bar-info > img {
+    width: 20px;
+    height: 20px;
+}
 #pds-app-bar-info > div {
     z-index: 1000;
     background-color: rgba(0,0,0,1);
     font-size: 12px;
     padding: 7px 8px;
     max-width: 580px;
-    left: 288px;
 }

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -108,6 +108,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
 		document.body.insertBefore(app_bar, document.body.firstChild);
 
+		var bar_first_style = bar_first.currentStyle || window.getComputedStyle(bar_first);
+		info_text.style.left = (bar_first.offsetWidth + parseFloat(bar_first_style.marginRight)).toString() + "px";
+
 		dropdown_link.onclick = function() {
 			dropdown_container.classList.toggle("active");
 		};


### PR DESCRIPTION
PDS app bar is wider than some mobile device screens and clickable
elements are too close together.

Hardcoded placement of information text caused it to extend past the
screen (and had it misaligned with the information icon). Determine
placement by the width of the title/logo, which can change depending on
the device.

Enlarge the information icon and extend the space between it and the
adjacent drop-down menu.

See #9.