### PR TITLE
Check if composedPath is defined in App Bar close listener

### DIFF
--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -190,7 +190,7 @@
 
     document.body.onclick = function (e) {
       if (
-        !e.composedPath().some((el) => el.id === "pds-app-bar-dropdown") &&
+        e.composedPath && !e.composedPath().some((el) => el.id === "pds-app-bar-dropdown") &&
         dropdown_container.classList.contains("active")
       ) {
         dropdown_container.classList.remove("active");


### PR DESCRIPTION
**Summary**
Checks if `composedPath` is defined in the App Bar's close event listener before calling it. Some components were bubbling up events that did not have this function and that was causing errors.

**Test Data and/or Report**
Tested in PJ Beta and change successfully restores functionality to facets on the page.

**Related Issues**
* Fixes #15 - App Bar breaks facet selection on Photojournal Beta
