### PR TITLE
Fix z-placement of PDS App Bar

### DIFF
--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -14,6 +14,7 @@
 
 #pds-app-bar {
     position: relative;
+    z-index: 2;
     top: 0;
     left: 0;
     max-width: 100vw;
@@ -92,7 +93,6 @@
 }
 
 #pds-app-bar-dropdown > ul {
-    z-index: 999;
     background-color: rgba(0,0,0,0.95);
     padding: 3px 5px;
 }


### PR DESCRIPTION
Apply z-index rule to the parent container to make use of the hierarchy
of stacking contexts.

Resolves issue for pdssbn.astro.umd.edu.
