### PR TITLE
Node-specific styles and General improvements on focus and hover

### DIFF
--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -83,7 +83,7 @@
 #pds-app-bar-info > div {
     display: none;
     position: absolute;
-    top: 35px;
+    top: 31px;
     margin: 0;
     border-radius: 0 0 3px 3px;
 }
@@ -101,7 +101,7 @@
 
 #pds-app-bar-dropdown > ul {
     background-color: rgba(0,0,0,0.95);
-    padding: 3px 5px;
+    padding: 7px 5px 3px;
 }
 #pds-app-bar-dropdown > ul li {
     list-style-type: none;
@@ -122,7 +122,7 @@
     z-index: 1000;
     background-color: rgba(0,0,0,1);
     font-size: 12px;
-    padding: 7px 8px;
+    padding: 11px 8px 7px;
     max-width: 580px;
 }
 

--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -38,6 +38,11 @@
     cursor: pointer;
     background-image: none;
 }
+#pds-app-bar a,
+#pds-app-bar a:hover {
+    /* to override PPI's expand.css */
+    background-color: transparent;
+}
 
 .pds-app-bar-section:first-child {
     margin-right: 70px;

--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -43,10 +43,11 @@
 }
 
 .pds-app-bar-section:first-child {
-    margin-right: 70px;
+    margin-right: 65px;
 }
 #pds-app-bar-title {
     font-size: 16px;
+    padding: 2px 5px 2px 0;
 }
 #pds-app-bar-title img {
     display: flex;
@@ -58,7 +59,7 @@
 
 #pds-app-bar-dropdown > a {
     font-size: 14px;
-    padding: 8px 5px;
+    padding: 4px;
 }
 #pds-app-bar-dropdown > a > span {
     margin-left: 0.5em;
@@ -115,6 +116,7 @@
 #pds-app-bar-info > img {
     width: 18px;
     height: 18px;
+    padding: 3px;
 }
 #pds-app-bar-info > div {
     z-index: 1000;

--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -24,6 +24,7 @@
     background: #000;
     box-sizing: content-box;
     border-bottom: 1px solid rgba(121,121,124,0.75);
+    text-align: left;
 }
 
 #pds-app-bar * {
@@ -37,11 +38,8 @@
     text-decoration: none;
     cursor: pointer;
     background-image: none;
-}
-#pds-app-bar a,
-#pds-app-bar a:hover {
-    /* to override PPI's expand.css */
     background-color: transparent;
+    border: none;
 }
 
 .pds-app-bar-section:first-child {

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -120,8 +120,9 @@
     document.body.insertBefore(app_bar, document.body.firstChild);
 
     // handlers for Information popup
-    var bar_first_style = bar_first.currentStyle || window.getComputedStyle(bar_first);
-    info_text.style.left = (bar_first.offsetWidth + parseFloat(bar_first_style.marginRight)).toString() + "px";
+    var bar_first_style = bar_first.currentStyle || window.getComputedStyle(bar_first),
+        info_icon_style = info_icon.currentStyle || window.getComputedStyle(info_icon);
+    info_text.style.left = (bar_first.offsetWidth + parseFloat(bar_first_style.marginRight) + parseFloat(info_icon_style.paddingLeft)).toString() + "px";
 
     info_container.onmouseover = function () {
       info_container.classList.add("active");

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -124,10 +124,10 @@
         info_icon_style = info_icon.currentStyle || window.getComputedStyle(info_icon);
     info_text.style.left = (bar_first.offsetWidth + parseFloat(bar_first_style.marginRight) + parseFloat(info_icon_style.paddingLeft)).toString() + "px";
 
-    info_container.onmouseover = function () {
+    info_container.onmouseenter = function () {
       info_container.classList.add("active");
     };
-    info_container.onmouseout = function () {
+    info_container.onmouseleave = function () {
       info_container.classList.remove("active");
     };
     info_container.onfocus = function () {
@@ -173,10 +173,10 @@
         dropdown_container.classList.add("active");
       }
     }
-    dropdown_container.onmouseover = function () {
+    dropdown_container.onmouseenter = function () {
       dropdown_container.classList.add("active");
     };
-    dropdown_container.onmouseout = function () {
+    dropdown_container.onmouseleave = function () {
       reset_dropdown_tabindices();
       close_dropdown_list();
     };


### PR DESCRIPTION
**Summary**
Update style for specific nodes and improve the look and behavior of elements on focus and hover.

For specific nodes: 
- link elements on hover: background-color (PPI)
- link elements on hover: border (PPI)
- all elements: text-alignment (IMG)

For general improvements on focus and hover:
- give padding to elements which have a border on focus
   - PDS title and logo
   - information icon
   - "Find a Node"
- maintain visibility of information and nodes dropdown with mouse movements

**Test Data and/or Report**
Updates are on _gamma_ site. For comparison to...

node-specific updates:
- link element background-color at [PPI](https://pds-ppi.igpp.ucla.edu/): hover over a Node name from the dropdown under "Find a Node" (or look at [this comment](https://github.com/NASA-PDS/pds-wds-web/issues/27#issuecomment-915356828))
- link element border at [PPI](https://pds-ppi.igpp.ucla.edu/): hover over "Find a Node"
- text-alignment at [IMG](https://pds-imaging.jpl.nasa.gov/): hover over information icon or "Find a Node"

general improvements:
- focus elements at https://pds.nasa.gov/: load page and press 'Tab' key
- hover continuity at https://pds.nasa.gov/

**Related Issues**
TBD