### PR TITLE
change dropdown link to button

### DIFF
--- a/app-bar/pds-app-bar/pds-app-bar.css
+++ b/app-bar/pds-app-bar/pds-app-bar.css
@@ -57,27 +57,29 @@
     margin-right: 5px;
 }
 
-#pds-app-bar-dropdown > a {
+#pds-app-bar-dropdown > button {
     font-size: 14px;
     padding: 4px;
-}
-#pds-app-bar-dropdown > a > span {
-    margin-left: 0.5em;
-}
-#pds-app-bar-dropdown > a > span:after {
-    display: inline-flex;
-    justify-content: center;
-    content: "\2023";
     color: #f5f5f6;
-    width: 21px;
-    -webkit-transform: scale(2.5,1.5) rotate(90deg);
-       -moz-transform: scale(2.5,1.5) rotate(90deg);
-            transform: scale(2.5,1.5) rotate(90deg);
+    background-color: transparent;
+    border: none;
+    border-image: none;
+    display: flex;
+    align-items: center;
 }
-#pds-app-bar-dropdown.active > a > span:after {
-    -webkit-transform: scale(2.5,1.5) rotate(270deg);
-       -moz-transform: scale(2.5,1.5) rotate(270deg);
-            transform: scale(2.5,1.5) rotate(270deg);
+#pds-app-bar-dropdown > button:after {
+    display: inline-flex;
+    content: "";
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 5px 4px 0 4px;
+    border-color: #f5f5f6 transparent transparent transparent;
+    margin-left: 15px;
+}
+#pds-app-bar-dropdown.active > button:after {
+    border-width: 0 4px 5px 4px;
+    border-color: transparent transparent #f5f5f6 transparent;
 }
 #pds-app-bar-dropdown > ul,
 #pds-app-bar-info > div {
@@ -91,7 +93,7 @@
 #pds-app-bar-info.active > div{
     display: block;
 }
-#pds-app-bar-dropdown > a,
+#pds-app-bar-dropdown > button,
 #pds-app-bar-dropdown > ul li,
 #pds-app-bar-dropdown > ul li > a {
     -webkit-transition: all 100ms ease;
@@ -129,7 +131,7 @@
 /* tabbable items */
 #pds-app-bar-title:focus,
 #pds-app-bar-info:focus,
-#pds-app-bar-dropdown:focus {
+#pds-app-bar-dropdown > button:focus {
     outline: thin dotted;
 }
 #pds-app-bar-dropdown > ul li:focus {

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -44,7 +44,7 @@
     bar_title.href = "https://pds.nasa.gov/";
     bar_title.target = "_blank";
     bar_title.innerHTML =
-      "<img src='https://pds.nasa.gov/pds-app-bar/images/PDS_Planets-acr-inv-bw.png' alt=''>Planetary Data System";
+      "<img src='https://pds.nasa.gov/pds-app-bar/images/PDS_Planets-acr-inv-bw.png' alt='PDS logo'>Planetary Data System";
     bar_first.appendChild(bar_title);
 
     var info_container = document.createElement("div"),

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -39,8 +39,7 @@
     bar_first.className = "pds-app-bar-section";
     bar_second.className = "pds-app-bar-section";
 
-    var bar_title = document.createElement("a"),
-      bar_logo = document.createElement("img");
+    var bar_title = document.createElement("a");
     bar_title.setAttribute("id", "pds-app-bar-title");
     bar_title.href = "https://pds.nasa.gov/";
     bar_title.target = "_blank";
@@ -54,10 +53,7 @@
     info_container.setAttribute("id", "pds-app-bar-info");
     info_container.setAttribute("tabindex", "0");
     info_icon.setAttribute("alt", "PDS Information");
-    info_icon.setAttribute(
-      "src",
-      "https://pds.nasa.gov/pds-app-bar/images/info.svg"
-    );
+    info_icon.setAttribute("src","https://pds.nasa.gov/pds-app-bar/images/info.svg");
     info_text.innerHTML =
       "Find a Node - Use these links to navigate to any of the 8 publicly accessible PDS Nodes." +
       "<br/><br/>" +
@@ -78,12 +74,18 @@
 
     var nodes = new Map();
     nodes
-      .set("atm", ["Atmospheres (ATM)", "https://pds-atmospheres.nmsu.edu/"])
+      .set("atm", [
+        "Atmospheres (ATM)",
+        "https://pds-atmospheres.nmsu.edu/"
+      ])
       .set("img", [
         "Cartography and Imaging Sciences (IMG)",
         "https://pds-imaging.jpl.nasa.gov/",
       ])
-      .set("geo", ["Geosciences (GEO)", "https://pds-geosciences.wustl.edu/"])
+      .set("geo", [
+        "Geosciences (GEO)",
+        "https://pds-geosciences.wustl.edu/"
+      ])
       .set("naif", [
         "Navigation & Ancillary Information Facility (NAIF)",
         "https://naif.jpl.nasa.gov/naif/",
@@ -92,7 +94,10 @@
         "Planetary Plasma Interactions (PPI)",
         "https://pds-ppi.igpp.ucla.edu/",
       ])
-      .set("rms", ["Ring-Moon Systems (RMS)", "https://pds-rings.seti.org/"])
+      .set("rms", [
+        "Ring-Moon Systems (RMS)",
+        "https://pds-rings.seti.org/"
+      ])
       .set("sbn", [
         "Small Bodies (SBN)",
         "https://pds-smallbodies.astro.umd.edu/",

--- a/app-bar/pds-app-bar/pds-app-bar.js
+++ b/app-bar/pds-app-bar/pds-app-bar.js
@@ -64,13 +64,10 @@
     info_container.appendChild(info_text);
 
     var dropdown_container = document.createElement("div"),
-      dropdown_link = document.createElement("a"),
-      dropdown_caret = document.createElement("span"),
+      dropdown_button = document.createElement("button"),
       dropdown_list = document.createElement("ul");
     dropdown_container.setAttribute("id", "pds-app-bar-dropdown");
-    dropdown_container.setAttribute("tabindex", "0");
-    dropdown_link.textContent = "Find a Node";
-    dropdown_link.appendChild(dropdown_caret);
+    dropdown_button.textContent = "Find a Node";
 
     var nodes = new Map();
     nodes
@@ -113,7 +110,7 @@
       li.appendChild(node);
       dropdown_list.appendChild(li);
     }
-    dropdown_container.appendChild(dropdown_link);
+    dropdown_container.appendChild(dropdown_button);
     dropdown_container.appendChild(dropdown_list);
 
     bar_second.appendChild(info_container);
@@ -170,7 +167,7 @@
           focused_element_exists = false;
           dropdown_container.classList.remove("active");
         };
-    dropdown_caret.onclick = function () {
+    dropdown_button.onclick = function () {
       if (dropdown_container.classList.contains("active")) {
         reset_dropdown_tabindices();
         close_dropdown_list();
@@ -185,7 +182,7 @@
       reset_dropdown_tabindices();
       close_dropdown_list();
     };
-    dropdown_container.onfocus = function () {
+    dropdown_button.onfocus = function () {
       dropdown_container.classList.add("active");
     };
     for (let i = 0; i < dropdown_list_length; i++) {


### PR DESCRIPTION
## 🗒️ Summary
https://pds-atmospheres.nmsu.edu/data_and_services/atmospheres_data/catalog.htm
and like pages have javascript which colors certain links red. Rather
than also resorting to javascript, and because the behavior better fits
a button rather than a link, I changed the dropdown link to a button.

- change dropdown link to button
- remove focus capability from dropdown container
- remove unnecessary span element from button
- replace unwieldy caret (plain styling instead of CSS code)
- make entire button clickable, not just the caret
- add 'alt' to PDS logo
- clean up and format javascript

For accessibility, a button must be focusable, so I removed the focus
from the container and applied the style and behavior to the new button.
The way the caret is presented (formerly with a CSS code) had to be
changed because its shape extended beyond the button, changing the shape
of the outline when focused. The span element was removed because it
seemed unnecessary. If I had done it before for a specific reason, I
don't recall it, and this'll (hopefully) teach me to document better.

This has been deployed to gamma and production (although not yet merged).

## ⚙️ Test Data and/or Report
Screenshot of issue: https://github.com/NASA-PDS/pds-wds-web/issues/31#issue-1211622968

## ♻️ Related Issues
Fixes https://github.com/NASA-PDS/pds-wds-web/issues/31


